### PR TITLE
Update KTheory2.tex

### DIFF
--- a/K-Theory/Chapters/KTheory2.tex
+++ b/K-Theory/Chapters/KTheory2.tex
@@ -629,7 +629,7 @@ The \enquote{idea} how to impose commutativity is to replace $\IDelta^\op$ by so
 		\Cut(\alpha^\op)(i)=\begin{cases*}
 			\text{undefined} & if $i\leq\alpha(0)$\\
 			j & if $\alpha(j-1)<i\leq \alpha(j)$\\
-			\text{undefined} & if $\alpha(n)<i$
+			\text{undefined} & if $\alpha(m)<i$
 		\end{cases*}\,.
 	\end{equation*}
 	In more invariant words, $\Cut$ sends a finite non-empty totally ordered set $I\in \IDelta^\op$ to its set of \emph{Dedekind cuts} (i.e.\ partitions into two non-empty intervals), and a map $\alpha\colon I\morphism J$ in $\IDelta$ is sent to $\Cut(\alpha^\op)=\alpha^*\colon \Cut(J)\morphism \Cut(I)$ which is given by taking preimages (whenever these are non-empty, otherwise it's undefined).


### PR DESCRIPTION
Fixed typo in II.15 on the definition of the cut functor. See p.33 of the 2nd set of Hebestreit's Bonn lecture notes or p. 67 of his Summer 24 lecture notes (https://drive.google.com/file/d/1rQn6KuwEGfAUur7Y_2OXAvhyS2lJs-sc/view). 